### PR TITLE
ラベルファイルをUTF-8で読み込むようにする

### DIFF
--- a/create_dataset_jtalk.py
+++ b/create_dataset_jtalk.py
@@ -45,7 +45,7 @@ def create_dataset(filename):
             continue
         counter = 0
         for lab, wav in zip(lab_file_list, wav_file_list):
-            with open(lab, 'r') as f:
+            with open(lab, 'r', encoding="utf-8") as f:
                 mozi = f.read().split("\n")
             print(str(mozi))
             test = mozi2phone(str(mozi))


### PR DESCRIPTION
題の通りです。
デフォルトのcp932だと読み込めない(エラーを吐く)ことがあるので、utf-8を使用するように変更します。