### PR TITLE
gitignoreへ*.spec.ptを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # 
 .history
 logs/
+*.spec.pt


### PR DESCRIPTION
*.spec.pt は学習音声データファイルから生成されるスペクトログラムデータファイルなのでgitignoreに追加しました。