### PR TITLE
V1.2.1.2

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -183,7 +183,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         random.shuffle(self.audiopaths_sid_text)
         self._filter()
 
-    @retry(exceptions=(IOError), tries=10, delay=1)
+    @retry(tries=30, delay=10)
     def _filter(self):
         """
         Filter text & store spec lengths

--- a/mel_processing.py
+++ b/mel_processing.py
@@ -64,7 +64,8 @@ def spectrogram_torch(y, n_fft, sampling_rate, hop_size, win_size, center=False)
     y = y.squeeze(1)
 
     spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
-                      center=center, pad_mode='reflect', normalized=False, onesided=True)
+                      center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=True)
+    spec = torch.view_as_real(spec)
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
     return spec
@@ -102,7 +103,8 @@ def mel_spectrogram_torch(y, n_fft, num_mels, sampling_rate, hop_size, win_size,
     y = y.squeeze(1)
 
     spec = torch.stft(y, n_fft, hop_length=hop_size, win_length=win_size, window=hann_window[wnsize_dtype_device],
-                      center=center, pad_mode='reflect', normalized=False, onesided=True)
+                      center=center, pad_mode='reflect', normalized=False, onesided=True, return_complex=True)
+    spec = torch.view_as_real(spec)
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + 1e-6)
 

--- a/train_ms.py
+++ b/train_ms.py
@@ -17,7 +17,7 @@ import datetime
 import pytz
 import time
 from tqdm import tqdm
-import warnings
+#import warnings
 
 
 import commons
@@ -41,9 +41,9 @@ from mel_processing import mel_spectrogram_torch, spec_to_mel_torch
 from text.symbols import symbols
 
 #stftの警告対策
-warnings.resetwarnings()
-warnings.simplefilter('ignore', UserWarning)
-warnings.simplefilter('ignore', DeprecationWarning)
+#warnings.resetwarnings()
+#warnings.simplefilter('ignore', UserWarning)
+#warnings.simplefilter('ignore', DeprecationWarning)
 
 torch.backends.cudnn.benchmark = True
 global_step = 0


### PR DESCRIPTION
・data_utilsのretryする条件を緩和
・torch.stftのtorch-1.8以降対応
>stftがtorch-1.8ではreturn_complex=Trueが標準となるため