### PR TITLE
スタート時の0での保存やめてlatestをlog_intervalのタイミングで残す

### DIFF
--- a/train_ms.py
+++ b/train_ms.py
@@ -251,8 +251,10 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
           global_step=global_step, 
           images=image_dict,
           scalars=scalar_dict)
+        utils.save_checkpoint(net_g, optim_g, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "G_latest_99999999.pth"))
+        utils.save_checkpoint(net_d, optim_d, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "D_latest_99999999.pth"))
 
-      if global_step % hps.train.eval_interval == 0:
+      if global_step % hps.train.eval_interval == 0 and global_step != 0:
         evaluate(hps, net_g, eval_loader, writer_eval, logger)
         utils.save_checkpoint(net_g, optim_g, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "G_{}.pth".format(global_step)))
         utils.save_checkpoint(net_d, optim_d, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "D_{}.pth".format(global_step)))


### PR DESCRIPTION
log_intervalを1000とか短めにしてeval_intervalを10000とかにすると、Colabなどで途中で落ちた場合でも途中までの学習結果を無駄にせず、またDriveの容量をあまり使わずに学習をすすめられるようになります
latestの名前は「G_latest_99999999.pth」のように到達しないであろう学習回数を指定しています
