### PR TITLE
学習データ読み込み時のassertでエラーメッセージついてないの対応

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -16,7 +16,7 @@ logger = logging
 
 
 def load_checkpoint(checkpoint_path, model, optimizer=None):
-  assert os.path.isfile(checkpoint_path)
+  assert os.path.isfile(checkpoint_path), f"No such file or directory: {checkpoint_path}"
   checkpoint_dict = torch.load(checkpoint_path, map_location='cpu')
   iteration = checkpoint_dict['iteration']
   learning_rate = checkpoint_dict['learning_rate']


### PR DESCRIPTION
学習データ読み込み時にファイルが見つからないときassertにエラーメッセージがないためわからなくなっていたのを修正しました。