### PR TITLE
pipパッケージ一覧をrequirements.txt化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+pip-packages/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/notebook/02_Train_MMVC.ipynb
+++ b/notebook/02_Train_MMVC.ipynb
@@ -125,20 +125,7 @@
       "outputs": [],
       "source": [
         "!apt-get install espeak\n",
-        "!pip install Cython==0.29.21\n",
-        "!pip install librosa==0.8.0\n",
-        "!pip install matplotlib==3.3.1\n",
-        "!pip install numpy\n",
-        "!pip install phonemizer==2.2.1\n",
-        "!pip install scipy==1.5.2\n",
-        "!pip install tensorboard==2.3.0\n",
-        "!pip install torch==1.8.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html\n",
-        "!pip install torchvision==0.9.0\n",
-        "!pip install torchaudio==0.8.0\n",
-        "!pip install Unidecode==1.1.1\n",
-        "!pip install retry\n",
-        "!pip install tqdm\n",
-        "!pip install resampy==0.2.2"
+        "!pip install -r requirements.txt"
       ]
     },
     {

--- a/notebook/03_MMVC_Interface.ipynb
+++ b/notebook/03_MMVC_Interface.ipynb
@@ -107,19 +107,7 @@
       "outputs": [],
       "source": [
         "!apt-get install espeak\n",
-        "!pip install Cython==0.29.21\n",
-        "!pip install librosa==0.8.0\n",
-        "!pip install matplotlib==3.3.1\n",
-        "!pip install numpy==1.18.5\n",
-        "!pip install phonemizer==2.2.1\n",
-        "!pip install scipy==1.5.2\n",
-        "!pip install tensorboard==2.3.0\n",
-        "!pip install torch==1.8.0\n",
-        "!pip install torchvision==0.9.0\n",
-        "!pip install torchaudio==0.8.0\n",
-        "!pip install Unidecode==1.1.1\n",
-        "!pip install retry\n",
-        "!pip install resampy==0.2.2"
+        "!pip install -r requirements.txt"
       ]
     },
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+pyopenjtalk
+Cython==0.29.21
+librosa==0.8.0
+matplotlib==3.3.1
+numpy
+phonemizer==2.2.1
+scipy==1.5.2
+tensorboard==2.3.0
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.8.0+cu111
+torchvision==0.9.0
+torchaudio==0.8.0
+Unidecode==1.1.1
+retry
+tqdm
+resampy==0.2.2

--- a/requirements_wsl2.txt
+++ b/requirements_wsl2.txt
@@ -1,0 +1,20 @@
+pyopenjtalk
+Cython==0.29.21
+librosa==0.8.0
+matplotlib==3.3.1
+phonemizer==2.2.1
+scipy==1.5.2
+tensorboard==2.3.0
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.8.0+cu111
+torchvision==0.9.0
+torchaudio==0.8.0
+Unidecode==1.1.1
+retry
+tqdm
+resampy==0.2.2
+
+# Specific package for WSL2
+psutil
+protobuf==3.19.0
+numpy==1.22


### PR DESCRIPTION
- パッケージ管理をrequirements.txtに一元化することで、今後のメンテナンス性が向上する
    - MMVC_Trainerで利用するパッケージをpipの一般的な手法で明示できる。 
    - notebookの2か所の記載を共通化でき、今後パッケージを更新した際にrequirements.txtのみ更新すれば良くなる。
    - WSL2用のパッケージ導入が楽になる。
        - 従来のlinux用に `requirements.txt`  , WSL用に `requirements_wsl2.txt`を用意
    - 開発ディレクトリ下にパッケージをインストールしやすくなる。
        - グローバルpipを汚さないのでパッケージバージョンの異なるMMVC_Trainerをディレクトリ別で管理できるようになる。
        -  [もっと気軽にpip install - Qiita](https://qiita.com/non_cal/items/1f3a910eb55427b193a3)
            - `pip install -r requirements_wsl2.txt -t pip-packages`
            - `export PYTHONPATH="${PYTHONPATH}:./pip-packages"`
- 動作確認
    - Google Colaboratory
    - WSL2