### PR TITLE
保存モデルの軽減

### DIFF
--- a/configs/baseconfig.json
+++ b/configs/baseconfig.json
@@ -1,7 +1,11 @@
 {
   "train": {
-    "log_interval": 1000,
-    "eval_interval": 2000,
+    "eval_interval": 1000,
+    "backup": {
+      "step": 2000,
+      "best": true,
+      "g_only": true
+    },
     "seed": 1234,
     "epochs": 10000,
     "learning_rate": 0.0002,

--- a/configs/baseconfig.json
+++ b/configs/baseconfig.json
@@ -2,7 +2,7 @@
   "train": {
     "eval_interval": 1000,
     "backup": {
-      "step": 2000,
+      "interval": 2000,
       "best": true,
       "g_only": true
     },

--- a/train_ms.py
+++ b/train_ms.py
@@ -266,6 +266,7 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
         utils.save_checkpoint(net_d, optim_d, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "D_latest_99999999.pth"))
 
       if global_step % hps.train.backup.interval == 0 and global_step != 0:
+        evaluate(hps, net_g, eval_loader, writer_eval, logger)
         if hps.train.backup.g_only == False:
           utils.save_checkpoint(net_d, optim_d, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "D_{}.pth".format(global_step)))
 

--- a/train_ms.py
+++ b/train_ms.py
@@ -265,7 +265,7 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
         utils.save_checkpoint(net_g, optim_g, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "G_latest_99999999.pth"))
         utils.save_checkpoint(net_d, optim_d, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "D_latest_99999999.pth"))
 
-      if global_step % hps.train.backup.step == 0 and global_step != 0:
+      if global_step % hps.train.backup.interval == 0 and global_step != 0:
         if hps.train.backup.g_only == False:
           utils.save_checkpoint(net_d, optim_d, hps.train.learning_rate, epoch, os.path.join(hps.model_dir, "D_{}.pth".format(global_step)))
 


### PR DESCRIPTION

学習モデルおよびVCサンプル音声の出力条件を変更。
それに合わせてconfig.jsonのパラメータを変更。

**削除**
- log_interval


**変更**
- eval_interval
D_latest_99999999.pth、G_latest_99999999.pthを出力するよう変更。
D_xxxxx.pth、G_xxxxx.pthを出力しないよう変更。
VCサンプルを出力しないよう変更。


**新規追加**
- backup
1. interval(旧来のeval_intervalと同機能)
設定したstep数に到達した際に処理開始。
D_xxxxx.pth、G_xxxxx.pthを出力。
D_latest_99999999.pth、G_latest_99999999.pthを出力。
vc_xxxxx.wavを出力。

2. best
trueにすることで有効化。
eval_interval時にloss g/melが最低値を記録した際に処理開始。
D_best.pth、G_best.pthを出力
best.logにstep数、loss g/mel、サーバー日時を書き込む
vc_best.wavを出力。

3. g_only
trueにすることで有効化。
backupモデルが出力される際にGモデルのみ出力するようにする。