### PR TITLE
v1.4向けに話者IDを変更

### DIFF
--- a/configs/baseconfig.json
+++ b/configs/baseconfig.json
@@ -18,13 +18,13 @@
     "warmup_epochs": 0,
     "c_mel": 45,
     "c_kl": 1.0,
-    "note_kl": 0.25
+    "note_kl": 0.10
   },
   "data": {
-    "training_files": "filelists/dec_not_propagation_label_and_change_melspec_textful.txt",
-    "validation_files": "filelists/dec_not_propagation_label_and_change_melspec_textful_val.txt",
-    "training_files_notext": "filelists/dec_not_propagation_label_and_change_melspec_textless.txt",
-    "validation_files_notext": "filelists/dec_not_propagation_label_and_change_melspec_val_textless.txt",
+    "training_files": "filelists/train_config_textful.txt",
+    "validation_files": "filelists/train_config_textful_val.txt",
+    "training_files_notext": "filelists/train_config_textless.txt",
+    "validation_files_notext": "filelists/train_config_val_textless.txt",
     "Correspondence": "filelists/dec_not_propagation_label_and_change_melspec_val_textless.txt",
     "text_cleaners": [
       "japanese_cleaners"
@@ -38,7 +38,7 @@
     "mel_fmin": 0.0,
     "mel_fmax": null,
     "add_blank": true,
-    "n_speakers": 110,
+    "n_speakers": 255,
     "cleaned_text": false
   },
   "model": {
@@ -87,7 +87,7 @@
     ],
     "n_layers_q": 3,
     "use_spectral_norm": false,
-    "n_flow": 8,
+    "n_flow": 12,
     "gin_channels": 256,
     "n_note": 79
   },
@@ -95,19 +95,19 @@
     "os_type": "linux"
   },
   "augmentation": {
-    "enable"               : false,
-    "gain_p"               : 0.5,
-    "min_gain_in_db"       : -10,
-    "max_gain_in_db"       :  10,
-    "time_stretch_p"       : 0.5,
-    "min_rate"             : 0.75,
-    "max_rate"             : 1.25,
-    "pitch_shift_p"        : 0.0,
-    "min_semitones"        : -4.0,
-    "max_semitones"        :  4.0,
-    "add_gaussian_noise_p" : 0.0,
-    "min_amplitude"        : 0.001,
-    "max_amplitude"        : 0.04,
-    "frequency_mask_p"     : 0.0
+    "enable": false,
+    "gain_p": 0.5,
+    "min_gain_in_db": -10,
+    "max_gain_in_db": 10,
+    "time_stretch_p": 0.5,
+    "min_rate": 0.75,
+    "max_rate": 1.25,
+    "pitch_shift_p": 0.0,
+    "min_semitones": -4.0,
+    "max_semitones": 4.0,
+    "add_gaussian_noise_p": 0.0,
+    "min_amplitude": 0.001,
+    "max_amplitude": 0.04,
+    "frequency_mask_p": 0.0
   }
 }

--- a/create_dataset_jtalk.py
+++ b/create_dataset_jtalk.py
@@ -13,7 +13,7 @@ from scipy.io import wavfile
 NUM_MAX_SID = 255
 #JVS+Zun+Sora+Me+Tsum+Tsuk+NICT*2 = 107
 NUM_TRAINED_SPEAKER = 107
-ZUNDAMON_SID = 100
+ZUNDAMON_SID = 101
 MY_SID = 0
 
 
@@ -378,9 +378,9 @@ def main():
     parser.add_argument('-s', '--sr', type=int, default=24000,
                         help='sampling rate (default = 24000)')
     parser.add_argument('-t', '--target', type=int, default=9999,
-                        help='pre_traind targetid (zundamon = 100, sora = 101, methane = 102, tsumugi = 103)')
+                        help='pre_traind targetid (zundamon = 101, sora = 102, methane = 103, tsumugi = 104)')
     parser.add_argument('-m', '--multi_target', type=str, default=None,
-                        help='pre_traind targetid (zundamon = 100, sora = 101, methane = 102, tsumugi = 103)')
+                        help='pre_traind targetid (zundamon = 101, sora = 102, methane = 103, tsumugi = 104)')
     parser.add_argument('-c', '--config', type=str, default="./configs/baseconfig.json",
                         help='JSON file for configuration')
     args = parser.parse_args()
@@ -388,7 +388,7 @@ def main():
     print(filename)
     if args.multi_target != None:
         n_spk = create_dataset_multi_character(filename, args.multi_target)
-    elif args.target != 9999 and args.target == 100:
+    elif args.target != 9999 and args.target == 101:
         n_spk = create_dataset_zundamon(filename)
     elif args.target != 9999:
         n_spk = create_dataset_character(filename, args.target)

--- a/create_dataset_jtalk_feature.py
+++ b/create_dataset_jtalk_feature.py
@@ -289,7 +289,7 @@ def create_dataset_zundamon(filename, my_sid):
         counter = counter +1
     Correspondence_list.append(str(speaker_id)+"|"+os.path.basename(d) + "\n")
 
-    speaker_id = 100
+    speaker_id = 101
     d = zundamon_path
     wav_file_list = glob.glob(d + "/wav/*.wav")
     lab_file_list = glob.glob(d + "/text/*.txt")

--- a/notebook/01_Create_Configfile.ipynb
+++ b/notebook/01_Create_Configfile.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# MMVCの学習に必要なconfig系Fileを作成する\n",
         "\n",
-        "ver.2022/08/18\n",
+        "ver.2022/09/05\n",
         "\n"
       ]
     },
@@ -107,8 +107,8 @@
       },
       "outputs": [],
       "source": [
-        "!fileid=\"1MRmB-9EL2-xhxIIraVx20qWqyX-8ZMPw\"; filename=\"fine_model/G_180000.pth\"; html=`curl -c ./cookie -s -L \"https://drive.google.com/uc?export=download&id=${fileid}\"`; curl -Lb ./cookie \"https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\\-_]+)'`&id=${fileid}\" -o ${filename}\n",
-        "!fileid=\"1oPbMM7cGz-z0fLgj7DW_wPGRCwvgD2jZ\"; filename=\"fine_model/D_180000.pth\"; html=`curl -c ./cookie -s -L \"https://drive.google.com/uc?export=download&id=${fileid}\"`; curl -Lb ./cookie \"https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\\-_]+)'`&id=${fileid}\" -o ${filename}"
+        "!fileid=\"1QZ-YTBKBRP0wt33H_eu93ud804kt448n\"; filename=\"fine_model/G_70000.pth\"; html=`curl -c ./cookie -s -L \"https://drive.google.com/uc?export=download&id=${fileid}\"`; curl -Lb ./cookie \"https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\\-_]+)'`&id=${fileid}\" -o ${filename}\n",
+        "!fileid=\"1HfHng7bGJUGi5OaUmaQ0p8wsnX3EK8Yq\"; filename=\"fine_model/D_70000.pth\"; html=`curl -c ./cookie -s -L \"https://drive.google.com/uc?export=download&id=${fileid}\"`; curl -Lb ./cookie \"https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\\-_]+)'`&id=${fileid}\" -o ${filename}"
       ]
     },
     {
@@ -146,7 +146,7 @@
         "オプションは-f -s -tがあります。普通に使う際には-cは不要です。  \n",
         "-f 作成するconfig系Fileの名前です。よくわからない人は変更不要です。  \n",
         "-s サンプリングレートです。datasetの音声のサンプリングレートに合わせて指定ください。よくわからない人は変更不要です。  \n",
-        "-t 既にモデルに学習されているデータの場合利用します。ずんだもんの場合は「100」 それ以外のサポートキャラは「101～103」 非サポートキャラは「108」を指定します。\n",
+        "-t 既にモデルに学習されているデータの場合利用します。ずんだもんの場合は「101」 それ以外のサポートキャラは「102～104」 非サポートキャラは「108」を指定します。\n",
         "\n",
         "\n",
         "実行時に  \n",
@@ -182,7 +182,7 @@
       },
       "outputs": [],
       "source": [
-        "!python create_dataset_jtalk.py -f train_config_zundamon -s 24000 -t 100"
+        "!python create_dataset_jtalk.py -f train_config_zundamon -s 24000 -t 101"
       ]
     },
     {
@@ -193,9 +193,9 @@
       "source": [
         "### 5.2 ずんだもん以外の話者の学習を行う\n",
         "ずんだもん以外の話者の学習を行う場合、下記セルを実行してください。  \n",
-        "**九州そらの学習を行いたい場合、「108」を「101」に  \n",
-        "四国めたんの学習を行いたい場合、「108」を「102」に  \n",
-        "春日部つむぎの学習を行いたい場合、「108」を「103」に**  \n",
+        "**九州そらの学習を行いたい場合、「108」を「102」に  \n",
+        "四国めたんの学習を行いたい場合、「108」を「103」に  \n",
+        "春日部つむぎの学習を行いたい場合、「108」を「104」に**  \n",
         "設定するとクオリティがあがる**かも**しれません。"
       ]
     },

--- a/notebook/02_Train_MMVC.ipynb
+++ b/notebook/02_Train_MMVC.ipynb
@@ -7,7 +7,7 @@
       },
       "source": [
         "# MMVC Trainer\n",
-        "ver.2022/08/10"
+        "ver.2022/09/05"
       ]
     },
     {
@@ -193,7 +193,7 @@
         "-fg にFine tuningのベースとなるG_xxxx.pth のpathを指定してください。  \n",
         "-fd にFine tuningのベースとなるD_xxxx.pth のpathを指定してください。  \n",
         "**よくわからないよって人は**    \n",
-        "-fg fine_model/G_180000.pth -fd fine_model/D_180000.pth \n",
+        "-fg fine_model/G_70000.pth -fd fine_model/D_70000.pth \n",
         "のままにしておいてください。\n",
         "\n",
         "2回目以降の実行の場合は自動的に-mで指定したディレクトリの最新のモデルから学習を再開します。  \n",
@@ -210,7 +210,7 @@
       },
       "outputs": [],
       "source": [
-        "!python train_ms.py -c configs/train_config_zundamon.json -m 20220306_24000 -fg fine_model/G_180000.pth -fd fine_model/D_180000.pth"
+        "!python train_ms.py -c configs/train_config_zundamon.json -m 20220306_24000 -fg fine_model/G_70000.pth -fd fine_model/D_70000.pth"
       ]
     },
     {
@@ -250,7 +250,7 @@
       },
       "outputs": [],
       "source": [
-        "!python train_ms.py -c configs/train_config.json -m 20220306_24000 -fg fine_model/G_180000.pth -fd fine_model/D_180000.pth"
+        "!python train_ms.py -c configs/train_config.json -m 20220306_24000 -fg fine_model/G_70000.pth -fd fine_model/D_70000.pth"
       ]
     },
     {

--- a/notebook/03_MMVC_Interface.ipynb
+++ b/notebook/03_MMVC_Interface.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# モデルの精度を確認するためのインターフェース\n",
         "\n",
-        "ver.2022/09/04"
+        "ver.2022/09/05"
       ]
     },
     {
@@ -197,7 +197,7 @@
       "outputs": [],
       "source": [
         "CONFIG_PATH = \"./configs/train_config_zundamon.json\"\n",
-        "NET_PATH = \"./logs/20220306_24000/G_xxxxx.pth\""
+        "NET_PATH = \"./logs/20220306_24000/G_latest_99999999.pth\""
       ]
     },
     {


### PR DESCRIPTION
話者IDがv1.4から変更されたため、
ずんだもんのIDを101に変更
九州そらのIDを102に変更
四国めたんのIDを103に変更
春日部つむぎのIDを104に変更

configパラメータが変更されたため、
baseconfig.jsonをv1.4向けパラメータに変更。データオーグメンテーションはデフォルトでfalseになる。

学習済みモデルが変更されたため、
01_Create_Configfile.ipynbにてG,D_70000.pthにダウンロードリンクを変更
02_Train_MMVC.ipynbにてG,D_180000.pthをG,D_70000.pthに変更

デフォルトの状態で学習モデルを読み込めるようにするため、
03_MMVC_InterfaceにてNET_PATHのデフォルトをG_latest_99999999.pthに変更