### PR TITLE
学習時ログ出力の修正

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -164,7 +164,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         2) normalizes text and converts them to sequences of integers
         3) computes spectrograms from audio files.
     """
-    def __init__(self, audiopaths_sid_text, hparams, no_text=False, augmentation=False, augmentation_params=None, no_use_textfile = False):
+    def __init__(self, audiopaths_sid_text, hparams, no_text=False, augmentation=False, augmentation_params=None, no_use_textfile = False, disable_tqdm = False):
         if no_use_textfile:
             self.audiopaths_sid_text = list()
         else:
@@ -198,6 +198,8 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         self.add_blank = hparams.add_blank
         self.min_text_len = getattr(hparams, "min_text_len", 1)
         self.max_text_len = getattr(hparams, "max_text_len", 1000)
+        
+        self.disable_tqdm = disable_tqdm
 
         random.seed(1234)
         random.shuffle(self.audiopaths_sid_text)
@@ -215,7 +217,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         audiopaths_sid_text_new = []
         lengths = []
         
-        for audiopath, sid, text in tqdm.tqdm(self.audiopaths_sid_text):
+        for audiopath, sid, text in tqdm.tqdm(self.audiopaths_sid_text, disable=self.disable_tqdm):
             if self.min_text_len <= len(text) and len(text) <= self.max_text_len:
                 audiopaths_sid_text_new.append([audiopath, sid, text])
                 lengths.append(os.path.getsize(audiopath) // (2 * self.hop_length))

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ from scipy.io.wavfile import read
 import torch
 import wave
 import csv
+import warnings
 
 MATPLOTLIB_FLAG = False
 
@@ -165,7 +166,10 @@ def plot_alignment_to_numpy(alignment, info=None):
 
 
 def load_wav_to_torch(full_path):
-  sampling_rate, data = read(full_path)
+  #音声にメタデータが含まれる際のWavFileWarning対策
+  with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    sampling_rate, data = read(full_path)
   return torch.FloatTensor(data.astype(np.float32)), sampling_rate
 
 

--- a/utils.py
+++ b/utils.py
@@ -66,7 +66,7 @@ def save_vc_sample(hps, loader, collate, generator, name):
     target_id = hps.others.target_id
 
     with torch.no_grad():
-      dataset = loader(hps.data.validation_files_notext, hps.data)
+      dataset = loader(hps.data.validation_files_notext, hps.data, disable_tqdm=True)
       data = dataset.get_audio_text_speaker_pair([input_filename, source_id, "a"])
       data = collate()([data])
       x, x_lengths, spec, spec_lengths, y, y_lengths, sid_src = [x.cuda(0) for x in data]


### PR DESCRIPTION
- WavFileWarning対策
warnings.simplefilterを使って当該箇所のみwarningを非表示にしました。
- VCサンプル出力時の不要なプログレスバー
TextAudioSpeakerLoaderにデフォルトがFalseの引数disable_tqdmを追加して、Trueが渡された場合のみ_filter内のtqdmが非表示になるようにしました。