### PR TITLE
onnx_exportで利用するためクライアントの設定ファイルを置く

### DIFF
--- a/configs/myprofile.conf
+++ b/configs/myprofile.conf
@@ -1,0 +1,36 @@
+{
+  "device": {
+    "input_device1": "マイク (Realtek(R) Audio), MME",
+    "input_device2": false,
+    "output_device": "スピーカー (Realtek(R) Audio), MME",
+    "gpu_id": 0
+  },
+  "vc_conf": {
+    "frame_length": 8192,
+    "delay_flames": 4096,
+    "overlap": 1024,
+    "dispose_stft_specs": 2,
+    "dispose_conv1d_specs": 10,
+    "source_id": 0,
+    "target_id": 101,
+    "f0_scale": 1.0,
+    "mic_scale": 1.0,
+    "onnx": {
+      "use_onnx": true,
+      "onnx_providers": ["DmlExecutionProvider", "CPUExecutionProvider"]
+    }
+  },
+  "path": {
+    "json": ".\\logs\\20220306_24000\\config.json",
+    "model": ".\\logs\\20220306_24000\\G_latest_99999999.onnx",
+    "correspondence":".\\logs\\20220306_24000\\train_config_Correspondence.txt",
+    "noise": ".\\noise.wav"
+  },
+  "others": {
+    "use_nr": false,
+    "voice_selector": false,
+    "voice_list": [101, 108, 6, 30],
+    "voice_label": ["ずんだもん", "目標話者", "女性の声", "男性の低い声"],
+    "voice_f0": [1.0, 1.0, 1.0, 1.0]
+  }
+}


### PR DESCRIPTION
ONNXの入力を固定長にする必要があり、onnx_exportでクライアント設定ファイルを参照する必要があります。
デフォルトのクライアント設定ファイルを置いておくことで、通常のクライアント設定ファイルを変更していない場合はクライアント設定ファイルの内容を意識しなくてもよくなります。