### PR TITLE
V1.5.0.0 si fi gan

### DIFF
--- a/configs/myprofile.conf
+++ b/configs/myprofile.conf
@@ -1,0 +1,36 @@
+{
+  "device": {
+    "input_device1": "マイク (Realtek(R) Audio), MME",
+    "input_device2": false,
+    "output_device": "スピーカー (Realtek(R) Audio), MME",
+    "gpu_id": 0
+  },
+  "vc_conf": {
+    "frame_length": 8192,
+    "delay_flames": 4096,
+    "overlap": 1024,
+    "dispose_stft_specs": 2,
+    "dispose_conv1d_specs": 10,
+    "source_id": 0,
+    "target_id": 101,
+    "f0_scale": 1.0,
+    "mic_scale": 1.0,
+    "onnx": {
+      "use_onnx": true,
+      "onnx_providers": ["DmlExecutionProvider", "CPUExecutionProvider"]
+    }
+  },
+  "path": {
+    "json": ".\\logs\\20220306_24000\\config.json",
+    "model": ".\\logs\\20220306_24000\\G_latest_99999999.onnx",
+    "correspondence":".\\logs\\20220306_24000\\train_config_Correspondence.txt",
+    "noise": ".\\noise.wav"
+  },
+  "others": {
+    "use_nr": false,
+    "voice_selector": false,
+    "voice_list": [101, 108, 6, 30],
+    "voice_label": ["ずんだもん", "目標話者", "女性の声", "男性の低い声"],
+    "voice_f0": [1.0, 1.0, 1.0, 1.0]
+  }
+}

--- a/onnx_export.py
+++ b/onnx_export.py
@@ -193,8 +193,9 @@ def main(args):
         #(dummy_specs, dummy_lengths, dummy_f0, dummy_sid_src, dummy_sid_tgt),
         onnx_file,
         #do_constant_folding=False,
+        opset_version=11,
         #opset_version=13,
-        opset_version=17,
+        #opset_version=17,
         verbose=False,
         input_names=["specs", "lengths", "sin", "d0", "d1", "d2", "d3", "sid_src", "sid_tgt"],
         output_names=["audio"])


### PR DESCRIPTION
音声変換品質が著しく劣化する件の対処を行いました。
特定の条件のみこの問題が発生します。
- ONNXでExecutionProviderがDirectMLの場合のみ発生する（CPUやCUDAは問題ない）
- 学習済みpthに依存して発生する（pthによっては発生しない）
- ONNXのopset_version=12以降で発生する（12, 13, 17でテストしてどれも発生した）
- export時のdo_constant_foldingやsimplify、推論時のORT_ENABLE_BASICなどは影響しなかった
opset_versionが低いままにはあまりしたくないため、デコーダーの種類を変えたときのタイミングでopset_versionを上げても問題ないか確認して、問題が出なければ上げるようにするのが良いと思います。