### PR TITLE
ONNX変換元モデルのフォルダパスをtutorialに変更

### DIFF
--- a/notebook/04_Train_MMVC.ipynb
+++ b/notebook/04_Train_MMVC.ipynb
@@ -437,7 +437,7 @@
         "#@markdown ONNXファイルに変換するモデルを選択してください。\n",
         "\n",
         "#@markdown (基本的にvc_conf_passは設定変更不要です)\n",
-        "model_save_dic = \"20220306_24000\" #@param {type:\"string\"}\n",
+        "model_save_dic = \"tutorial\" #@param {type:\"string\"}\n",
         "model_pass = \"G_latest_99999999.pth\" #@param {type:\"string\"}\n",
         "vc_conf_pass = \"configs/myprofile.conf\" #@param {type:\"string\"}\n",
         "\n",


### PR DESCRIPTION
ONNX変換元モデルのフォルダパスを、「6 学習の設定」のデフォルトフォルダ名であるtutorialに変更