### PR TITLE
numba==0.48.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Cython==0.29.21
 librosa==0.8.0
 matplotlib==3.3.1
+numba==0.48.0
 numpy==1.23.5
 phonemizer==2.2.1
 scipy


### PR DESCRIPTION
`AttributeError: module 'numba' has no attribute 'core'
`

00_Rec_Voice.ipynbの"4 学習用音声を録音する"で上記エラーが発生しました。
numba のバージョンを0.48.0に固定することでエラーが無くなりました。

参考
https://github.com/numba/numba/issues/6246